### PR TITLE
Update s3leveldown.js: pass in s3 client

### DIFF
--- a/s3leveldown.js
+++ b/s3leveldown.js
@@ -192,7 +192,7 @@ S3Iterator.prototype._test = function () { return true }
 
 function S3LevelDOWN (location, s3) {
   if (!(this instanceof S3LevelDOWN))
-    return new S3LevelDOWN(location)
+    return new S3LevelDOWN(location, s3)
 
   if (typeof location !== 'string') {
     throw new Error('constructor requires a location string argument')


### PR DESCRIPTION
Logic to make sure S3LevelDOWN is called as a contructor never passed in the s3 client. This change makes sure the s3 client is passed.