### PR TITLE
fix: check for actual keys in object, since "{}" is truthy

### DIFF
--- a/s3leveldown.js
+++ b/s3leveldown.js
@@ -198,7 +198,7 @@ function S3LevelDOWN (location, s3) {
     throw new Error('constructor requires a location string argument')
   }
 
-  this.s3 = s3 || staticS3;
+  this.s3 = (s3 && Object.keys(s3).length > 0) || staticS3;
 
   if (location.indexOf('/') !== -1) {
     this.folderPrefix = location.substring(location.indexOf('/') + 1, location.length) + '/'


### PR DESCRIPTION
Passing in an empty object as options,  `{}` should not be considered truthy. Proposed change will fallback to `staticS3` if an empty object is used as options.